### PR TITLE
[feat] 월별 지출 조회 API 구현

### DIFF
--- a/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/controller/ExpenseController.java
+++ b/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/controller/ExpenseController.java
@@ -5,12 +5,17 @@ import com.ggv.wallet.expenditures.dto.request.DeleteExpenseRequest;
 import com.ggv.wallet.service.ExpenseService;
 import com.ggv.wallet.usecase.CreateExpenseUseCase;
 import com.ggv.wallet.usecase.DeleteExpenseUseCase;
+import com.ggv.wallet.usecase.ReadMonthlyExpenseUseCase;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,6 +33,17 @@ public class ExpenseController {
         expenseService.saveExpense(useCase);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/v1/wallet/expenses")
+    public ResponseEntity<ReadMonthlyExpenseUseCase> readMonthlyExpenses(
+            @Valid @Min(2000) @Max(2099) @RequestParam("year") int year, // TODO 유효성 관련 논의 필요
+            @Valid @Min(1) @Max(12) @RequestParam("month") int month
+    ) {
+        Long userId = 1L; // TODO 로그인 기능 구현되면 수정
+        ReadMonthlyExpenseUseCase monthlyExpenses = expenseService.findMonthlyExpenses(userId, year, month);
+
+        return ResponseEntity.ok(monthlyExpenses);
     }
 
     @DeleteMapping("/v1/wallet/expense")

--- a/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/controller/ExpenseController.java
+++ b/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/controller/ExpenseController.java
@@ -1,11 +1,14 @@
 package com.ggv.wallet.expenditures.controller;
 
 import com.ggv.wallet.expenditures.dto.CreateExpenseDto;
+import com.ggv.wallet.expenditures.dto.request.DeleteExpenseRequest;
 import com.ggv.wallet.service.ExpenseService;
 import com.ggv.wallet.usecase.CreateExpenseUseCase;
+import com.ggv.wallet.usecase.DeleteExpenseUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +25,18 @@ public class ExpenseController {
     ) {
         Long userId = 1L; // TODO 로그인 기능 구현되면 수정
         CreateExpenseUseCase useCase = request.toUseCase(userId);
-        expenseService.saveExpenditure(useCase);
+        expenseService.saveExpense(useCase);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/v1/wallet/expense")
+    public ResponseEntity<Void> deleteExpenses(
+            @Valid @RequestBody DeleteExpenseRequest request
+    ) {
+        Long userId = 1L; // TODO 로그인 기능 구현되면 수정
+        DeleteExpenseUseCase useCase = request.toUseCase(userId);
+        expenseService.deleteExpense(useCase);
 
         return ResponseEntity.ok().build();
     }

--- a/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/dto/request/DeleteExpenseRequest.java
+++ b/app/api/ggv/src/main/java/com/ggv/wallet/expenditures/dto/request/DeleteExpenseRequest.java
@@ -1,0 +1,19 @@
+package com.ggv.wallet.expenditures.dto.request;
+
+import com.ggv.wallet.usecase.DeleteExpenseUseCase;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record DeleteExpenseRequest(
+        @NotNull(message = "ID 리스트는 null일 수 없습니다.")
+        @NotEmpty(message = "ID 리스트는 비어 있을 수 없습니다.")
+        List<Long> ids
+) {
+    public DeleteExpenseUseCase toUseCase(Long userId) {
+        return new DeleteExpenseUseCase(
+                userId,
+                ids
+        );
+    }
+}

--- a/app/application/src/main/java/com/ggv/wallet/service/ExpenseService.java
+++ b/app/application/src/main/java/com/ggv/wallet/service/ExpenseService.java
@@ -2,6 +2,7 @@ package com.ggv.wallet.service;
 
 import com.ggv.infra.wallet.repository.ExpenseRepository;
 import com.ggv.wallet.usecase.CreateExpenseUseCase;
+import com.ggv.wallet.usecase.DeleteExpenseUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +15,12 @@ public class ExpenseService {
     private final ExpenseRepository expenseRepository;
 
     @Transactional
-    public void saveExpenditure(CreateExpenseUseCase useCase) {
+    public void saveExpense(CreateExpenseUseCase useCase) {
         expenseRepository.save(useCase.toEntity());
+    }
+
+    @Transactional
+    public void deleteExpense(DeleteExpenseUseCase useCase) {
+        expenseRepository.deleteByUserIdAndIdIn(useCase.userId(), useCase.userExpenseIds());
     }
 }

--- a/app/application/src/main/java/com/ggv/wallet/service/ExpenseService.java
+++ b/app/application/src/main/java/com/ggv/wallet/service/ExpenseService.java
@@ -1,8 +1,11 @@
 package com.ggv.wallet.service;
 
+import com.ggv.domain.wallet.UserExpense;
 import com.ggv.infra.wallet.repository.ExpenseRepository;
 import com.ggv.wallet.usecase.CreateExpenseUseCase;
 import com.ggv.wallet.usecase.DeleteExpenseUseCase;
+import com.ggv.wallet.usecase.ReadMonthlyExpenseUseCase;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,5 +25,10 @@ public class ExpenseService {
     @Transactional
     public void deleteExpense(DeleteExpenseUseCase useCase) {
         expenseRepository.deleteByUserIdAndIdIn(useCase.userId(), useCase.userExpenseIds());
+    }
+
+    public ReadMonthlyExpenseUseCase findMonthlyExpenses(Long userId, int year, int month) {
+        List<UserExpense> userExpenses = expenseRepository.findByUserIdAndYearAndMonth(userId, year, month);
+        return ReadMonthlyExpenseUseCase.from(userExpenses);
     }
 }

--- a/app/application/src/main/java/com/ggv/wallet/usecase/DeleteExpenseUseCase.java
+++ b/app/application/src/main/java/com/ggv/wallet/usecase/DeleteExpenseUseCase.java
@@ -1,0 +1,9 @@
+package com.ggv.wallet.usecase;
+
+import java.util.List;
+
+public record DeleteExpenseUseCase(
+        Long userId,
+        List<Long> userExpenseIds
+) {
+}

--- a/app/application/src/main/java/com/ggv/wallet/usecase/ReadMonthlyExpenseUseCase.java
+++ b/app/application/src/main/java/com/ggv/wallet/usecase/ReadMonthlyExpenseUseCase.java
@@ -1,0 +1,38 @@
+package com.ggv.wallet.usecase;
+
+import com.ggv.domain.wallet.UserExpense;
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+
+public record ReadMonthlyExpenseUseCase(
+        List<ReadDailyExpenseUseCase> expenses
+) {
+    public static ReadMonthlyExpenseUseCase from(List<UserExpense> userExpenses) {
+        return new ReadMonthlyExpenseUseCase(userExpenses.stream()
+                .map(ReadDailyExpenseUseCase::from)
+                .toList()
+        );
+    }
+
+    private record ReadDailyExpenseUseCase(
+            long id,
+            Instant dateTime,
+            String title,
+            double price
+    ) {
+
+        @Builder
+        private ReadDailyExpenseUseCase {
+        }
+
+        private static ReadDailyExpenseUseCase from(UserExpense userExpense) {
+            return ReadDailyExpenseUseCase.builder()
+                    .id(userExpense.getId())
+                    .dateTime(userExpense.getDateTime())
+                    .title(userExpense.getTitle())
+                    .price(userExpense.getPrice())
+                    .build();
+        }
+    }
+}

--- a/app/infra/src/main/java/com/ggv/infra/wallet/repository/ExpenseRepository.java
+++ b/app/infra/src/main/java/com/ggv/infra/wallet/repository/ExpenseRepository.java
@@ -1,7 +1,15 @@
 package com.ggv.infra.wallet.repository;
 
 import com.ggv.domain.wallet.UserExpense;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ExpenseRepository extends JpaRepository<UserExpense, Long> {
+
+    @Modifying
+    @Query("DELETE FROM UserExpense expense WHERE expense.userId = :userId AND expense.id IN :ids")
+    void deleteByUserIdAndIdIn(@Param("userId") Long userId, @Param("ids") List<Long> ids);
 }

--- a/app/infra/src/main/java/com/ggv/infra/wallet/repository/ExpenseRepository.java
+++ b/app/infra/src/main/java/com/ggv/infra/wallet/repository/ExpenseRepository.java
@@ -9,6 +9,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface ExpenseRepository extends JpaRepository<UserExpense, Long> {
 
+    @Query("SELECT userExpense FROM UserExpense userExpense "
+            + "WHERE userExpense.userId = :userId "
+            + "AND EXTRACT(YEAR FROM userExpense.dateTime) = :year "
+            + "AND EXTRACT(MONTH FROM userExpense.dateTime) = :month "
+            + "ORDER BY userExpense.dateTime ASC"
+    )
+    List<UserExpense> findByUserIdAndYearAndMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month
+    );
+
     @Modifying
     @Query("DELETE FROM UserExpense expense WHERE expense.userId = :userId AND expense.id IN :ids")
     void deleteByUserIdAndIdIn(@Param("userId") Long userId, @Param("ids") List<Long> ids);


### PR DESCRIPTION
## 👋 To Reviewers
- 일별 지출 조회 API도 구현이 필요할 것 같은데 우선 월별 지출 조회 API 구현했습니다.
- 연도 같은 경우 몇년도부터 몇년도까지를 지원할 것인지 논의가 필요할 것 같습니다.
- 구현하면서 고민이 되었던 부분은 엔티티를 조회해온 이후 `usecase`로 변환을 하는데 `usecase`가 `dto`랑 다를 것이 없을 것 같아서 그대로 응답으로 내보내었습니다. 이린이라면 어떻게 구현했을지 궁금합니다.

+) 커밋 내용이 섞여서 임시로 헤드 브랜치를 이전 PR 브랜치로 했습니다. 머지 전에 main 브랜치로 수정할 예정입니다.

## 📎 작업 내용
- 월별 지출 조회 API 구현